### PR TITLE
Fixed a few typos of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ INSTALLATION
 USAGE
 =====
 
-You can see the example of text search in `end2end_test.py <./tests/end2end.py>`_.
+You can see the example of text search in `end2end_test.py <./tests/end2end_test.py>`_.
 
 1. Encode the sentences and store in a key--value store.
 
@@ -37,6 +37,8 @@ You can see the example of text search in `end2end_test.py <./tests/end2end.py>`
     from semsis.encoder import SentenceEncoder
     from semsis.kvstore import KVStore
     from semsis.retriever import RetrieverFaissCPU
+    import math
+    import numpy as np
 
     TEXT = [
         "They listen to jazz and he likes jazz piano like Bud Powell.",
@@ -84,7 +86,7 @@ You can see the example of text search in `end2end_test.py <./tests/end2end.py>`
 
 .. code:: python
 
-    retriever = RetrieverFaissCPU.load(index_path, cfg_path)
+    retriever = RetrieverFaissCPU.load(INDEX_PATH, INDEX_CONFIG_PATH)
     query_vectors = encoder.encode(QUERYS).numpy()
     distances, indices = retriever.search(query_vectors, k=1)
 


### PR DESCRIPTION
`import math` is required because of here
https://github.com/de9uch1/semsis/blob/d5573d2f36c886a2445415e26b599fffcb09b408/README.rst?plain=1#L67

`import numpy as np` is required because of here
https://github.com/de9uch1/semsis/blob/d5573d2f36c886a2445415e26b599fffcb09b408/README.rst?plain=1#L92